### PR TITLE
Modifier répertoires scannés pour config par défaut

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,7 +56,7 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.haul.yaml)")
+	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default: `.haul.yaml` in '.' or '/etc/haul')")
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -65,12 +65,9 @@ func initConfig() {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
 	} else {
-		// Find home directory.
-		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
-
-		// Search config in home directory with name ".haul" (without extension).
-		viper.AddConfigPath(home)
+		// Search config in current directory with name ".haul" (without extension).
+		viper.AddConfigPath(".")
+		viper.AddConfigPath("/etc/haul")
 		viper.SetConfigType("yaml")
 		viper.SetConfigName(".haul")
 	}


### PR DESCRIPTION
Retirer recherche dans home directory

Ajouter recherche dans current directory (en priorité)

Ajouter recherche dans /etc/haul/ (en second, si aucun flag ou fichier local ne vient remplir la config)