### PR TITLE
Compléter config d'example depuis config-port.yaml

### DIFF
--- a/examples/config-example.toml
+++ b/examples/config-example.toml
@@ -1,0 +1,21 @@
+## Server directives ##
+[server]
+
+# Port on which to run haul.
+port = 1312
+
+
+## Database directives ##
+[db]
+
+# The database type.
+#
+# Currently only supports sqlite3 (as 'sqlite').
+type = 'sqlite'
+
+# The path to the sqlite3 database file.
+#
+# Can be anywhere accessible to the user running haul, and
+# can be called anything as long as the extension is
+# supported by viper.
+path = '/srv/haul/haul.db'

--- a/examples/config-example.yaml
+++ b/examples/config-example.yaml
@@ -1,0 +1,21 @@
+## Server directives ##
+server:
+
+  # Port on which to run haul.
+  port: 1312
+
+
+## Database directives ##
+db:
+
+  # The database type.
+  #
+  # Currently only supports sqlite3 (as 'sqlite').
+  type: sqlite
+
+  # The path to the sqlite3 database file.
+  #
+  # Can be anywhere accessible to the user running haul, and
+  # can be called anything as long as the extension is
+  # supported by viper.
+  path: /srv/haul/haul.db

--- a/examples/config-port.yaml
+++ b/examples/config-port.yaml
@@ -1,7 +1,0 @@
-# Example haul config - custom port for server
-#
-# cli flag 'port' points to config 'server.port',
-#
-# and flags have precedence over config files (as per viper).
-server:
-  port: 1312


### PR DESCRIPTION
Split config d'example en 2 flavors (toml et yaml) pour montrer que plusieurs syntaxes sont acceptées.

Retirer examples/config-port.yaml