### PR TITLE
Changer field de structs redondant `ID` pour `Name`

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -17,13 +17,13 @@ import (
 
 type Asset struct {
 	gorm.Model
-	ID          string `json:"id"`
+	Name        string `json:"name"`
 	Description string `json:"description"`
 }
 
 type Assembly struct {
 	gorm.Model
-	ID          string `json:"id"`
+	Name        string `json:"name"`
 	Description string `json:"description"`
 	Final       bool   `json:"final"`
 }


### PR DESCRIPTION
gorm.Model crée déjà un field ID bien configuré, et Name sera plus utile anyways