### PR TITLE
Add a description to the root command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,16 +35,7 @@ var cfgFile string
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "haul",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
+	Short: "A tool to track lab hardware during its extended lifecycle",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.


### PR DESCRIPTION
Replaced the default description from the cobra library for a short description that fits haul a bit better.

Also it's a nice test of the collaboration workflow on Github 👍 